### PR TITLE
export hashes for use within gulpfile

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,10 @@ module.exports.config = function(key, value) {
 	}
 };
 
+module.exports.hashes = function() {
+	return hashes;
+};
+
 // for testing. Don't use, may be removed or changed at anytime
 module.exports._hash = hash;
 module.exports._path_relative_to_project = path_relative_to_project;

--- a/test/main.js
+++ b/test/main.js
@@ -115,6 +115,29 @@ describe('gulp-buster', function() {
 			stream2.end();
 		});
 
+		it('should export hashes', function() {
+			var fileContentStr = "foo";
+
+			var stream = bust("output1.json");
+			var fakeFile = new File({
+				cwd: "/home/contra/",
+				base: "/home/contra/test",
+				path: "/home/contra/test/file.js",
+				contents: new Buffer(fileContentStr)
+			});
+
+			stream.on('data', function(newFile) {
+				var obj = JSON.parse(newFile.contents.toString());
+				should.exist(obj[bust._path_relative_to_project(fakeFile.cwd, fakeFile.path)]);
+			});
+			stream.write(fakeFile);
+			stream.end();
+
+			var hashes = bust.hashes();
+			hashes.should.have.property('output1.json');
+			hashes['output1.json'].should.have.property('test/file.js');
+		});
+
 
 	});
 


### PR DESCRIPTION
Export hashes so that they can be accessed from within the gulpfile. My use case for this is to hardcode the hashes into my jade templates so that they can be served using any web server.
