### PR TITLE
upgrade to through2 to explicitly return a stream in objectMode - fix…

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var crypto = require('crypto');
 var path = require('path');
-var through = require('through');
+var through = require('through2');
 var assign = require('object-assign');
 var defaults = require('lodash.defaults');
 var gutil = require('gulp-util');
@@ -69,9 +69,17 @@ module.exports = exports = function(options) {
 	var hashes = hashesStore[options.fileName] = hashesStore[options.fileName] || {},
 		hashingPromises = [];
 
-	function hashFile(file) {
-		if (file.isNull()) return; // ignore
-		if (file.isStream()) return this.emit('error', error('Streaming not supported'));
+	function hashFile(file, enc, cb) {
+		if (file.isNull()) {
+			cb();
+			return;
+		}
+
+		if (file.isStream()) {
+			this.emit('error', error('Streaming not supported'));
+			cb();
+			return;
+		}
 
 		// start hashing files as soon as they are received for maximum concurrency
 		hashingPromises.push(
@@ -80,27 +88,29 @@ module.exports = exports = function(options) {
 				hashes[relativePath(file.cwd, options.relativePath, file.path)] = sliceHash(hashed, options);
 			})
 		);
+
+		cb();
 	}
 
-	function endStream() {
+	function endStream(cb) {
+
 		Promise.all(hashingPromises).bind(this).then(function() {
 			return options.transform.call(undefined, assign({}, hashes));
 		}).then(function(transformed) {
 			return options.formatter.call(undefined, transformed);
 		}).then(function(formatted) {
 			if (typeof formatted !== 'string') throw error('Return/fulfill value of `options.formatter` must be a string');
-
-			this.emit('data', new gutil.File({
+			this.push(new gutil.File({
 				path: path.join(process.cwd(), options.fileName),
 				contents: new Buffer(formatted),
 			}));
-			this.emit('end');
 		}).catch(function(err) {
 			this.emit('error', err instanceof gutil.PluginError ? err : error(err));
-		});
+		})
+			.finally(cb);
 	}
 
-	return through(hashFile, endStream);
+	return through.obj(hashFile, endStream);
 };
 
 // for testing. Don't use, may be removed or changed at anytime

--- a/index.js
+++ b/index.js
@@ -71,14 +71,11 @@ module.exports = exports = function(options) {
 
 	function hashFile(file, enc, cb) {
 		if (file.isNull()) {
-			cb();
-			return;
+			return cb();
 		}
 
 		if (file.isStream()) {
-			this.emit('error', error('Streaming not supported'));
-			cb();
-			return;
+			return cb(error('Streaming not supported'));
 		}
 
 		// start hashing files as soon as they are received for maximum concurrency
@@ -107,7 +104,7 @@ module.exports = exports = function(options) {
 		}).catch(function(err) {
 			this.emit('error', err instanceof gutil.PluginError ? err : error(err));
 		})
-			.finally(cb);
+		.finally(cb);
 	}
 
 	return through.obj(hashFile, endStream);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "gulp-util": "^3.0.7",
     "lodash.defaults": "^4.0.1",
     "object-assign": "^4.0.1",
-    "through": "^2.3.8"
+    "through2": "^2.0.3"
   },
   "engines": {
     "node": ">= 0.10"

--- a/test/main.js
+++ b/test/main.js
@@ -438,5 +438,30 @@ describe('Configuration options', function() {
 			});
 			stream.end(file);
 		});
+
+		it('should ignore files with `null` content', function (done) {
+			var stream = bust();
+			var nullFile = file.clone();
+			nullFile.contents = null;
+			nullFile.isNull().should.be.true;
+			stream.on('data', function(newFile) {
+				parseFile(newFile).should.deepEqual({});
+				done();
+			});
+			stream.end(nullFile);
+		});
+
+		it('should throw a not supported error upon receiving a vinyl file with a stream as content', function(done) {
+			var bustStream = bust();
+			var Readable = require('stream').Readable;
+			var readableStream = new Readable();
+			var vinylFileWithStreamContent = file.clone();
+			vinylFileWithStreamContent.contents = readableStream;
+			vinylFileWithStreamContent.isStream().should.be.true;
+
+			(function() {bustStream.end(vinylFileWithStreamContent);}).should.throw('Streaming not supported');
+
+			done();
+		})
 	});
 });


### PR DESCRIPTION
…es some interobability issues

Hi @UltCombo 
This upgrades to `through2` which apparently uses node streams 3 instead of streams 1 and explicitly supports object streams through `trough.obj`. Tests are still all passing.

With the current version of gulp-buster I had some interobability issues with libraries like `stream-to-promise` which check whether the incoming stream is in objectMode or not and adapt their behaviour accordingly. Obviously gulp-buster should be in objectMode as it returns vinyl file objects, but `through` and node streams 1 don't officially support objectMode: https://github.com/dominictarr/through/issues/40 .

for reference, this was the bug I was facing with gulp-buster and which got fixed by upgrading to though2:

```js
const streamToPromise = require('stream-to-promise');
const gulp = require('gulp');
const buster = require('gulp-buster');

streamToPromise(
    gulp.src('ui/**/*')
      .pipe(buster())
)
.catch(e => console.trace(e));
```

prints:
```
Unhandled rejection TypeError: must start with number, buffer, array or string
    at fromObject (buffer.js:226:9)
    at new Buffer (buffer.js:65:10)
    at bufferize (/Users/d061084/dev/k5-work-activity/app/node_modules/stream-to-promise/index.js:40:43)
    at Array.map (native)
    at concat (/Users/d061084/dev/k5-work-activity/app/node_modules/stream-to-promise/index.js:26:34)
    at tryCatcher (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/util.js:16:23)
    at Promise._settlePromiseFromHandler (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/promise.js:510:31)
    at Promise._settlePromise (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/promise.js:567:18)
    at Promise._settlePromise0 (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/promise.js:612:10)
    at Promise._settlePromises (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/promise.js:691:18)
    at Async._drainQueue (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/async.js:138:16)
    at Async._drainQueues (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/async.js:148:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/Users/d061084/dev/k5-work-activity/app/node_modules/bluebird/js/release/async.js:17:14)
    at processImmediate [as _immediateCallback] (timers.js:383:17)
```


